### PR TITLE
fixing payment errors

### DIFF
--- a/frontend/src/components/Checkout/CheckoutForm.tsx
+++ b/frontend/src/components/Checkout/CheckoutForm.tsx
@@ -89,9 +89,9 @@ function CheckoutForm() {
         setErrors("Payment declined, please try a different card.");
       } else {
       setErrors("Invalid card details");
-      setIsLoading(false);
-      return;
     }
+    setIsLoading(false);
+    return;
     }
 
     if (!paymentIntent || paymentIntent.status !== "succeeded") {


### PR DESCRIPTION
payment errors are defaulting to payment failed instead of custom messages